### PR TITLE
Fix negative lookahead

### DIFF
--- a/lib/rsec/parsers/misc.rb
+++ b/lib/rsec/parsers/misc.rb
@@ -64,10 +64,9 @@ module Rsec #:nodoc
     def _parse ctx
       res = left()._parse ctx
       pos = ctx.pos
-      if INVALID[right()._parse ctx]
-        ctx.pos = pos
-        res
-      end
+      return INVALID unless INVALID[right()._parse ctx]
+      ctx.pos = pos
+      res
     end
   end
 

--- a/test/test_lookahead.rb
+++ b/test/test_lookahead.rb
@@ -13,4 +13,10 @@ class TestLookAhead < TC
     ase ['a', 'c'], p.parse('ac')
     ase INVALID, p.parse('ab')
   end
+
+  def test_negative_lookahead
+    p = 'a'.r ^ 'b'
+    ase 'a', p.parse('ac')
+    ase INVALID, p.parse('ab')
+  end
 end


### PR DESCRIPTION
Negative lookahead didn't seem to quite work correctly.

```ruby
[3] pry(main)> p = 'a'.r ^ 'b'.r
=> #<struct Rsec::NegativeLookAhead left=#<struct Rsec::Pattern some=/a/>, right=#<struct Rsec::Pattern some=/b/>>
[4] pry(main)> p.parse!('ab')
=> nil # This should be a syntax error
[5] pry(main)> p.parse!('ac')
=> "a"
```

The relatively simple change to `NegativeLookAhead` should, to my understanding, fix the issue. It's just an inverse of `LookAhead`.