### PR TITLE
Replace Fixnum with Integer

### DIFF
--- a/lib/rsec/helpers.rb
+++ b/lib/rsec/helpers.rb
@@ -87,7 +87,7 @@ module Rsec #:nodoc:
         raise 'Floating points does not allow :base'
       end
       base ||= 10
-      Rsec.assert_type base, Fixnum
+      Rsec.assert_type base, Integer
       unless (2..36).include? base
         raise RangeError, ":base should be in 2..36, but got #{base}"
       end


### PR DESCRIPTION
Fixnum has been deprecated in Ruby 2.4. Any users of this library now gets a deprecation warning on newer rubies, and will eventually cause this library to be incompatible once Fixnum is removed.
Fixnum has been inheriting from Integer since at least ruby 1.9, so this change is safe.