### PR TITLE
Pass context to map

### DIFF
--- a/lib/rsec/parsers/misc.rb
+++ b/lib/rsec/parsers/misc.rb
@@ -5,7 +5,7 @@ module Rsec #:nodoc
     def _parse ctx
       res = left()._parse ctx
       return INVALID if INVALID[res]
-      right()[res]
+      right()[res, ctx]
     end
   end
 

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -41,6 +41,18 @@ class TestMisc < TC
     ase 'bb', p.parse('b')
     ase INVALID, p.parse('.')
   end
+
+  def test_seq_map
+    p = seq('"'.r, /\w/.r, '"'.r).map{|(_, n, _)| n*2}
+    ase 'bb', p.parse('"b"')
+    ase INVALID, p.parse('.')
+  end
+
+  def test_seq_map_with_context
+    p = seq('"'.r, /\w/.r, '"'.r).map{|(_, n, _), ctx| n*ctx.pos}
+    ase 'bbb', p.parse('"b"')
+    ase INVALID, p.parse('.')
+  end
   
   def test_fail
     p = 'v'.r.fail 'omg!'


### PR DESCRIPTION
Parsers may want to attach contextual information, such as line number
and position, to the AST nodes they are creating while parsing. One way
to create such AST nodes is by transforming rule results with `map`.
However, the current `map` implementation only receives the results
generated by the rule, so there is no way to grab the current context.

This PR attempts to solve this problem by passing the `ctx` object as
a second argument to map. This seems to maintain backwards compatibility
because Procs can ignore this parameter. However, I am not familiar with
the codebase and do not understand if there are other implications or
other ways to achieve the desired resul.